### PR TITLE
Adding CURD Enum to make sure crud operation detection stays uniform

### DIFF
--- a/com/restaurantdeliverymodels/CRUDAction.java
+++ b/com/restaurantdeliverymodels/CRUDAction.java
@@ -1,0 +1,5 @@
+package com.restaurantdeliverymodels;
+
+public enum CRUDAction {
+	Create, Read, Edit, Delete
+}


### PR DESCRIPTION
Adding CURD Enum to make sure crud operation detection stays uniform though-out the project. Instead of a string like "create"/"add" use "CRUDAction.Create"